### PR TITLE
Problem: CI does not work on forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 go:
   - "1.x"
   - "1.10.x"
+go_import_path: github.com/dxpb/dxpb
 script:
   - diff -u <(echo -n) <(gofmt -d -s cmd internal)
   - go vet ./...


### PR DESCRIPTION
Solution: set go_import_path, and install dependencies to
build with capnproto.