### PR TITLE
Problem: xbps-bulk-builder -D flag inconsistent

### DIFF
--- a/assets/builder/xbps-bulk-builder.sh
+++ b/assets/builder/xbps-bulk-builder.sh
@@ -3,7 +3,7 @@
 # [-b builddir] where xbulk configures itself and the build output is logged
 #               default: clean out and (re)use $PWD/builddir
 
-# [-d distdir] $PWD/void-packages
+# [-D distdir] $PWD/void-packages
 # [-h hostdir] $PWD/hostdir
 # [-m masterdir] $PWD/chroot
 
@@ -32,7 +32,7 @@ XB_OVERLAYFS=
 
 USAGE="Usage: $0 [-a target] [-B boostrap] [-c conf] [-R repo] [-t|-N] [-D|-h|-m dir] [-b builddir]"
 
-while getopts a:B:b:c:d:h:m:NR:t OPT; do
+while getopts a:B:b:c:D:h:m:NR:t OPT; do
 	case "$OPT" in
 	a)
 		XB_CROSS="-a $OPTARG"
@@ -44,7 +44,7 @@ while getopts a:B:b:c:d:h:m:NR:t OPT; do
 		DXPB_BUILDDIR=$(realpath "$OPTARG")
 		mkdir -p "$DXPB_BUILDDIR"
 		;;
-	d)
+	D)
 		[ -d "$OPTARG" ] || {
 			printf "ERROR: Cannot find DISTDIR "
 			printf "'%s': No such file or directory.\n" "$OPTARG"


### PR DESCRIPTION
Solution: make usage listing and actual flag consistent. I decided to use -D
instead of -d for destdir, since xbps-bulk does also, and -d is used for debug
output in much of the rest of the toolchain.